### PR TITLE
Better identification of the key type.

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -2,24 +2,19 @@
 
 @interface UIKBTree : NSObject
 @property NSInteger type;
-- (NSString *)name;
+- (BOOL)_renderAsStringKey;
 @end
 
 NSInteger popupState = 4;
 NSInteger normalState = 2;
-
-NSArray *whitelist()
-{
-	return @[@"International-Key", @"Delete-Key", @"Return-Key", @"Shift-Key", @"More-Key", @"Dictation-Key", @"Space-Key"];
-}
 
 %hook UIKBTree
 
 - (BOOL)canFadeOutFromState:(NSInteger)fromState toState:(NSInteger)toState
 {
 	BOOL stateOk = (fromState == popupState || fromState == normalState) && (toState == popupState || toState == normalState);
-	BOOL notInList = ![whitelist() containsObject:self.name];
-	return stateOk && notInList ? YES : %orig;
+	BOOL isCharacter = [self _renderAsStringKey];
+	return stateOk && isCharacter ? YES : %orig;
 }
 
 %end


### PR DESCRIPTION
This uses a default function to determine if the key is a string key, thus preventing the need to iterate the array of excluded names upon each key press. It may provide better support for some foreign languages that have other accessory keys.
